### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: steampunk
 name: unit
-version: 0.7.0
+version: 0.7.1
 readme: README.md
 authors:
   - XLAB Steampunk <steampunk@xlab.si>


### PR DESCRIPTION
There are no functional changes in this release. The only reason we created it is to force galaxy page update that is currently missing a link to the documentation site.